### PR TITLE
Add explicit imports to improve import hygiene

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SBMLToolkit"
 uuid = "86080e66-c8ac-44c2-a1a0-9adaadfe4a4e"
-authors = ["paulflang", "anandijain"]
 version = "0.1.31"
+authors = ["paulflang", "anandijain"]
 
 [deps]
 Catalyst = "479239e8-5488-4da2-87a7-35f2df7eef83"
@@ -14,6 +14,7 @@ CSV = "0.10.5"
 Catalyst = "14, 15"
 DataFrames = "1"
 Downloads = "1"
+ExplicitImports = "1.14.0"
 ModelingToolkit = "9"
 OrdinaryDiffEq = "6.42"
 Plots = "1.11"
@@ -30,6 +31,7 @@ Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 CSV = "336ed68f-0bac-5ca0-87d4-7b16caf5d00b"
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
 Downloads = "f43a241f-c20a-4ad4-852c-f6b1247861c6"
+ExplicitImports = "7d51a73a-1435-4ff3-83d9-f097790105c7"
 ModelingToolkit = "961ee093-0014-501f-94e3-6117800e7a78"
 OrdinaryDiffEq = "1dea7af3-3e70-54e6-95c3-0bf5283fa5ed"
 Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
@@ -39,4 +41,4 @@ Sundials = "c3572dad-4567-51f8-b174-8c6c989267f4"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Aqua", "CSV", "DataFrames", "Downloads", "ModelingToolkit", "OrdinaryDiffEq", "Plots", "SafeTestsets", "SBMLToolkitTestSuite", "Sundials", "Test"]
+test = ["Aqua", "CSV", "DataFrames", "Downloads", "ExplicitImports", "ModelingToolkit", "OrdinaryDiffEq", "Plots", "SafeTestsets", "SBMLToolkitTestSuite", "Sundials", "Test"]

--- a/src/SBMLToolkit.jl
+++ b/src/SBMLToolkit.jl
@@ -1,8 +1,14 @@
 module SBMLToolkit
 
-using Catalyst
-using SBML
-using SymbolicUtils
+# Catalyst exports and re-exports from ModelingToolkit/Symbolics
+using Catalyst: Catalyst, @parameters, @species, Equation, ModelingToolkit, Num,
+                ODESystem, Reaction, ReactionSystem, Symbolics, complete,
+                default_t, default_time_deriv, isspecies
+# SBML imports
+using SBML: SBML, convert_promotelocals_expandfuns, readSBML,
+            readSBMLFromString, set_level_and_version
+# SymbolicUtils imports
+using SymbolicUtils: SymbolicUtils, expand, simplify, substitute
 
 include("drafts.jl")
 include("systems.jl")

--- a/test/explicit_imports.jl
+++ b/test/explicit_imports.jl
@@ -1,0 +1,6 @@
+using ExplicitImports
+using SBMLToolkit
+using Test
+
+@test check_no_implicit_imports(SBMLToolkit) === nothing
+@test check_no_stale_explicit_imports(SBMLToolkit) === nothing

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,6 +4,9 @@ using SafeTestsets, Test
     @safetestset "Quality Assurance" begin
         include("qa.jl")
     end
+    @safetestset "Explicit Imports" begin
+        include("explicit_imports.jl")
+    end
     @safetestset "Systems" begin
         include("systems.jl")
     end


### PR DESCRIPTION
## Summary

- Replace blanket `using Catalyst/SBML/SymbolicUtils` with selective imports
- Add ExplicitImports.jl test to ensure import hygiene is maintained
- Add ExplicitImports to test dependencies

The package was relying on 22 implicit imports from dependencies:
- From Catalyst: `@species`, `Reaction`, `ReactionSystem`, `default_t`, `default_time_deriv`, `isspecies`
- From ModelingToolkit (via Catalyst): `@parameters`, `Equation`, `ModelingToolkit`, `Num`, `ODESystem`, `complete`
- From SBML: `SBML`, `convert_promotelocals_expandfuns`, `readSBML`, `readSBMLFromString`, `set_level_and_version`
- From SymbolicUtils: `expand`, `simplify`, `substitute`

These are now explicitly imported, preventing breakage if upstream packages change their re-exports.

## Files Changed

- `src/SBMLToolkit.jl` - Added explicit imports
- `test/explicit_imports.jl` - New test file for ExplicitImports checks
- `test/runtests.jl` - Added Explicit Imports test
- `Project.toml` - Added ExplicitImports to test dependencies

## Test plan

- [x] ExplicitImports checks pass (no implicit imports, no stale imports)
- [x] Package loads correctly
- [x] Exports remain functional

cc @ChrisRackauckas

🤖 Generated with [Claude Code](https://claude.com/claude-code)