### PR TITLE
Fix deprecation warnings

### DIFF
--- a/src/SBMLToolkit.jl
+++ b/src/SBMLToolkit.jl
@@ -15,7 +15,8 @@ include("rules.jl")
 include("events.jl")
 include("utils.jl")
 
-@deprecate convert_simplify_math convert_promotelocals_expandfuns
+# Backward compatibility alias (SBMLToolkitTestSuite still uses this name)
+const convert_simplify_math = convert_promotelocals_expandfuns
 
 export ReactionSystem, ODESystem
 export readSBML, readSBMLFromString, set_level_and_version, convert_simplify_math,

--- a/src/reactions.jl
+++ b/src/reactions.jl
@@ -182,7 +182,7 @@ function get_massaction(
         stoich::Union{Vector{<:Real}, Nothing}
     )
     function check_args(x::SymbolicUtils.BasicSymbolic{Real})
-        return check_args(Val(SymbolicUtils.istree(x)), x)
+        return check_args(Val(SymbolicUtils.iscall(x)), x)
     end
 
     function check_args(::Val{true}, x::SymbolicUtils.BasicSymbolic{Real})

--- a/src/rules.jl
+++ b/src/rules.jl
@@ -75,7 +75,7 @@ function get_var_and_assignment(model, rule)
     if !haskey(merge(model.species, model.compartments, model.parameters), rule.variable)
         error("Cannot find target for rule with ID `$(rule.variable)`")
     end
-    var = create_var(rule.variable, IV)
+    var = create_var(rule.variable, IV; isbcspecies = true)
     math = extensive_kinetic_math(model, rule.math)
     vc = get_volume_correction(model, rule.variable)
     if !isnothing(vc)
@@ -87,7 +87,7 @@ function get_var_and_assignment(model, rule)
         comp = model.compartments[sp.compartment]
         comp.constant == false && sp.only_substance_units == false &&
             begin
-            c = create_var(sp.compartment, IV)
+            c = create_var(sp.compartment, IV; isbcspecies = true)
             assignment = c * assignment + var / c * D(c)
         end
     end


### PR DESCRIPTION
## Summary

- Replace deprecated `SymbolicUtils.istree` with `SymbolicUtils.iscall` in `get_massaction` (`src/reactions.jl:185`)
- Mark rule variables as boundary condition species (`isbcspecies = true`) in `get_var_and_assignment` (`src/rules.jl:78,90`) to fix Catalyst v15 compatibility where `ReactionSystem` rejects differential equations involving non-bc species
- Replace `@deprecate convert_simplify_math` with a `const` alias (`src/SBMLToolkit.jl:18`) to avoid errors when `SBMLToolkitTestSuite` (which still calls the old name) runs under `JULIA_DEPWARN=error`

All 118 tests pass with `JULIA_DEPWARN=error` after these changes (previously 3 errors + 9 failures).

## Details

### `istree` → `iscall`
`SymbolicUtils.istree` was deprecated in favor of `SymbolicUtils.iscall`. With `--depwarn=error`, this caused an error in the `get_massaction` function.

### Rate rule `isbcspecies` fix
Catalyst v15 added a check that rejects equations containing `Differential(t)(species)` for non-boundary-condition species inside `ReactionSystem`. The `get_var_and_assignment` function was creating rule variables without the `isbcspecies = true` flag, even though other code paths (`map_symbolics_ident`, `create_symbol`) correctly set this flag for rule-defined variables. This caused failures in test cases 00033, 00170, and 00325.

### `convert_simplify_math` alias
`SBMLToolkitTestSuite` v0.0.4 still calls `convert_simplify_math`. With `@deprecate`, this throws an error under `JULIA_DEPWARN=error`, causing all 9 simulation result test cases to fail. Replacing with a `const` alias preserves backward compatibility without triggering deprecation errors.

## Upstream deps that need fixes
- **SBMLToolkitTestSuite**: Should be updated to use `convert_promotelocals_expandfuns` instead of `convert_simplify_math`, after which the `@deprecate` can be restored in SBMLToolkit

## Test plan
- [x] Run `JULIA_DEPWARN=error julia --project -e 'using Pkg; Pkg.test()'` — all 118 tests pass
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)