### PR TITLE
Bump version to 0.1.35

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SBMLToolkit"
 uuid = "86080e66-c8ac-44c2-a1a0-9adaadfe4a4e"
 authors = ["paulflang", "anandijain"]
-version = "0.1.34"
+version = "0.1.35"
 
 [deps]
 Catalyst = "479239e8-5488-4da2-87a7-35f2df7eef83"


### PR DESCRIPTION
Automated patch version bump (0.1.34 -> 0.1.35) to release unreleased commits on `main` via JuliaRegistrator.