### PR TITLE
Release prep: bump SBMLToolkit to 0.1.36

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SBMLToolkit"
 uuid = "86080e66-c8ac-44c2-a1a0-9adaadfe4a4e"
 authors = ["paulflang", "anandijain"]
-version = "0.1.35"
+version = "0.1.36"
 
 [deps]
 Catalyst = "479239e8-5488-4da2-87a7-35f2df7eef83"


### PR DESCRIPTION
Patch release for accumulated docstring/QA/test-scaffolding changes since 0.1.35 (docstring addition, test-only SciMLTesting compat bump, QA config kwarg). No functional/API changes.