### PR TITLE
Remove QA self-source path

### DIFF
--- a/test/qa/Project.toml
+++ b/test/qa/Project.toml
@@ -5,9 +5,6 @@ SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 SciMLTesting = "09d9d899-5365-40a9-917a-5f67fddea283"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
-[sources]
-SBMLToolkit = {path = "../.."}
-
 [compat]
 Aqua = "0.8.16"
 SafeTestsets = "0.1, 1"


### PR DESCRIPTION
This PR should be ignored until reviewed by @ChrisRackauckas.

## Summary
- remove the redundant `SBMLToolkit = {path = "../.."}` self-source from `test/qa/Project.toml`
- keep the SciMLTesting QA setup and rendered public API docs check in `test/qa/qa.jl` unchanged

## Validation
- `GROUP=QA timeout 3600 /home/crackauc/.juliaup/bin/julia +release --color=no --project=. -e 'using Pkg; Pkg.test()'`
- `qa_projects=$(find test -path '*/qa/Project.toml' -print | sort); printf 'QA Project.toml files:\n%s\n' "$qa_projects"; matches=$(rg -n '^\[sources\]|\bpath\s*=' $qa_projects || true); if [ -n "$matches" ]; then printf '%s\n' "$matches"; exit 1; else echo 'OK: no [sources] tables or path entries found in QA Project.toml files'; fi`

Runic was not run because no Julia files were changed.