### PR TITLE
Release prep: bump version to 0.1.37

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SBMLToolkit"
 uuid = "86080e66-c8ac-44c2-a1a0-9adaadfe4a4e"
 authors = ["paulflang", "anandijain"]
-version = "0.1.36"
+version = "0.1.37"
 
 [deps]
 Catalyst = "479239e8-5488-4da2-87a7-35f2df7eef83"


### PR DESCRIPTION
## Summary

Bumps `version` in Project.toml from 0.1.36 to 0.1.37 to register the one unreleased commit sitting on top of the last registered version (0.1.36, commit c82ee3a).

## What changed since last release (c82ee3a → 7ff6599)

- #219 "Remove QA self-source path": removes a `[sources]` self-reference (`SBMLToolkit = {path = "../.."}`) from `test/qa/Project.toml`. This is a test/QA-infrastructure-only change — it does not touch any package source files, exported API, or `[compat]` bounds in the main `Project.toml`.

## Bump type

**PATCH** (0.1.36 → 0.1.37): the only change is to test QA tooling, no source or public API changes.

## Compat bounds

Not touched. The diff does not modify `[compat]` in the main `Project.toml`, and doesn't add any new usage of SciML-ecosystem APIs, so no lower-bound changes are warranted.