### PR TITLE
Repair SBML test-suite integration workflow

### DIFF
--- a/.github/workflows/SbmlTestSuite.yml
+++ b/.github/workflows/SbmlTestSuite.yml
@@ -9,17 +9,15 @@ jobs:
     if: github.event_name == 'workflow_dispatch' || github.actor == 'JuliaTagBot'
     name: ${{ matrix.package.repo }}/${{ matrix.package.group }}
     runs-on: ${{ matrix.os }}
-    continue-on-error: true
     env:
       GROUP: ${{ matrix.package.group }}
     strategy:
       fail-fast: false
       matrix:
-        julia-version: [1.6]
+        julia-version: [1]
         os: [ubuntu-latest]
         package:
           - {user: SciML, repo: SBMLToolkitTestSuite.jl, group: All}
-          - {user: SciML, repo: SBMLToolkit.jl, group: All}
 
     steps:
       - uses: actions/checkout@v7
@@ -37,16 +35,6 @@ jobs:
         shell: julia --color=yes --project=downstream {0}
         run: |
           using Pkg
-          try
-            # force it to use this PR's version of the package
-            Pkg.develop(PackageSpec(path="."))  # resolver may fail with main deps
-            Pkg.update()
-            Pkg.test()  # resolver may fail with test time deps
-          catch err
-            err isa Pkg.Resolve.ResolverError || rethrow()
-            # If we can't resolve that means this is incompatible by SemVer and this is fine
-            # It means we marked this as a breaking change, so we don't need to worry about
-            # Mistakenly introducing a breaking change, as we have intentionally made one
-            @info "Not compatible with this release." exception=err
-            exit(0)  # Exit immediately, as a success
-          end
+          Pkg.develop(PackageSpec(path="."))
+          Pkg.update()
+          Pkg.test()


### PR DESCRIPTION
Ignore this PR until it has been reviewed by @ChrisRackauckas.

## Audit finding

The SBML test-suite workflow could report success without exercising the external suite:

- the job was marked `continue-on-error`;
- resolver errors were caught and converted to exit code 0;
- the matrix included SBMLToolkit itself, despite this being the external SBMLToolkitTestSuite workflow;
- Julia 1.6 is outside the current compat range.

## Changes

- remove job-level failure suppression;
- allow resolver and test failures to propagate;
- run the external SBMLToolkitTestSuite entry only;
- use the current Julia 1 release channel.

## Local verification

- Runic: `.github/workflows/SbmlTestSuite.yml` formatted cleanly.
- actionlint: workflow passed static validation.
- Workflow-equivalent Julia 1.12.6 run: developed this SBMLToolkit checkout into SBMLToolkitTestSuite, selected `GROUP=All`, and ran `Pkg.test()`.
- Result: exit code 0 after 34m13s; `Core/sbmltestsuite.jl` ran through the SBML corpus and Pkg reported `SBMLToolkitTestSuite tests passed`.

This PR intentionally does not hide individual SBML corpus cases that the suite classifies as unsupported or expected; the authoritative package test command completed successfully.