### PR TITLE
Preserve SBML event trigger operand order

### DIFF
--- a/src/events.jl
+++ b/src/events.jl
@@ -7,10 +7,9 @@ function get_events(model)  # Todo: implement up or downpass and parameters
     mtk_evs = Pair{Vector{Equation}, Vector{Equation}}[]
     for (_, e) in evs
         trigger = SBML.extensive_kinetic_math(model, e.trigger.math)
-        trigger = Symbolics.unwrap(interpret_as_num(trigger, model))
         lhs, rhs = map(
-            x -> substitute(x, subsdict),
-            SymbolicUtils.arguments(trigger),
+            x -> substitute(Symbolics.unwrap(interpret_as_num(x, model)), subsdict),
+            trigger.args,
         )
         trig = [lhs ~ rhs]
         mtk_evas = Equation[]

--- a/test/events.jl
+++ b/test/events.jl
@@ -34,3 +34,6 @@ events_true = [
     [S2 / compartment ~ 0.5] => [S2 ~ 0],
 ]
 @test isequal(events, events_true)
+
+# Symbolic backends may represent `a > b` as `b < a`; retain the SBML operands.
+@test isequal(first(events[2])[1], S2 / compartment ~ 0.5)


### PR DESCRIPTION
Ignore this PR until it has been reviewed by @ChrisRackauckas.

## Summary

- Interpret the two documented SBML `MathApply` operands separately before constructing the ModelingToolkit trigger equation.
- Preserve SBML event-trigger operand order even when a symbolic backend canonicalizes `a > b` as `b < a`.
- Add a focused regression assertion for the `gt` trigger in SBML test-suite case 00041.

This is independent of #221 and does not change SBMLToolkitTestSuite compatibility or CI workflow configuration.

## Root cause

On a clean `main` checkout at `e750c2a`, I reproduced case 00041 with Julia 1.11.9 and the latest compatible stack:

- Catalyst 16.2.2
- ModelingToolkit 11.32.0
- ModelingToolkitBase 1.53.0
- SBML 1.6.0
- Symbolics 7.32.0
- SymbolicUtils 4.40.1

The second trigger was emitted as `[0.5 ~ S2(t) / compartment]` instead of `[S2(t) / compartment ~ 0.5]`.

I bisected SymbolicUtils from v4.23.1 to v4.24.0 with a semantic operand-order test. The first bad commit is `b4d7c57d24564e96423ff6111a1c789a77d6d8b0` (`avoid defining > since it causes many invalidations`). Its parent `00ac22b3b923f1205ab2674fb0c3116f4bc181f2` retains `x > 0.5` with arguments `[x, 0.5]`; the bad commit correctly falls back to Julia's `>(x, y) = y < x` and stores `[0.5, x]`. SBMLToolkit was therefore relying on post-interpretation relation arguments to retain source order.

## Local verification

- Clean-main latest-stack 00041 reproduction: failed as described above.
- Branch latest-stack 00041 fixture: passed; actual triggers are `[S1(t) / compartment ~ 0.1]` and `[S2(t) / compartment ~ 0.5]`.
- `GROUP=Core julia +1.11 --startup-file=no --project=. -e 'using Pkg; Pkg.test(; coverage=false)'`: passed. Relevant summaries include `Core/events.jl | 4/4` and `Core/wuschel.jl | 2/2`; the complete Core run exited successfully.
- `GROUP=QA julia +1.11 --startup-file=no --project=. -e 'using Pkg; Pkg.test(; coverage=false)'`: passed `19/19` on the latest stack above.
- `julia +1.12 --startup-file=no -m Runic --check .`: passed.
- `git diff --check`: passed.
