### PR TITLE
Verify intentional public reexports

### DIFF
--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -1,9 +1,27 @@
 using SBMLToolkit, Test
 using SciMLTesting
 
+const INTENTIONAL_PUBLIC_REEXPORTS = (
+    ODESystem = SBMLToolkit.ModelingToolkit.ODESystem,
+    ReactionSystem = SBMLToolkit.Catalyst.ReactionSystem,
+    convert_promotelocals_expandfuns = SBMLToolkit.SBML.convert_promotelocals_expandfuns,
+    convert_simplify_math = SBMLToolkit.SBML.convert_promotelocals_expandfuns,
+    readSBML = SBMLToolkit.SBML.readSBML,
+    readSBMLFromString = SBMLToolkit.SBML.readSBMLFromString,
+    set_level_and_version = SBMLToolkit.SBML.set_level_and_version,
+)
+
+@testset "Intentional public reexports" begin
+    @test Tuple(public_reexports(SBMLToolkit)) == keys(INTENTIONAL_PUBLIC_REEXPORTS)
+    for (name, owner_binding) in pairs(INTENTIONAL_PUBLIC_REEXPORTS)
+        @test getfield(SBMLToolkit, name) === owner_binding
+    end
+end
+
 run_qa(
     SBMLToolkit;
     explicit_imports = true,
+    reexports_allow = keys(INTENTIONAL_PUBLIC_REEXPORTS),
     api_docs_kwargs = (; rendered = true),
     aqua_kwargs = (;
         ambiguities = (; recursive = false),


### PR DESCRIPTION
Ignore this draft PR until reviewed by @ChrisRackauckas.

## Summary
- Define the exact seven dependency-owned bindings that SBMLToolkit intentionally exposes as its convenience facade.
- Assert that `public_reexports(SBMLToolkit)` matches that surface exactly.
- Assert that every exported binding remains identical to the corresponding Catalyst, ModelingToolkit, or SBML owner binding.
- Pass only that verified surface to `run_qa` through `reexports_allow`.

Removing or wrapping these exports would be a breaking API change: SBMLToolkit extends the owner generics directly, and its documented examples expose `ReactionSystem`, `ODESystem`, and the SBML reader/preprocessing functions from the package namespace.

## Bisect
With dependencies resolved today, `13db81e9c933de8fbfffcaeb47d5c03dba78609e` (`Update SciMLTesting QA docs checks`, #217) is the first failing repository revision. Its parent `f5f30dcb9af31ee7c15a021fed623c89ce1d2014` resolves SciMLTesting 1.8.0 and passes QA 17/17. The first bad revision raises SciMLTesting compatibility to 2.x; it now resolves 2.6.1 and fails QA 19/1 on the seven intentional reexports. The exports themselves predate that revision.

## Local validation
- PASS: Julia 1.12.6, `GROUP=QA Pkg.test(coverage = true)`: 28/28.
- PASS: Runic 1.5.1, repository-wide `Runic --check .`.
- PASS: `git diff --check`.
- NOT VALIDATED on Julia 1.10: the exact command fails before loading tests on unmodified `bb863863` because the checked-in Julia 1.12.6 manifest contains the Julia-1.12-only `JuliaSyntaxHighlighting` stdlib. That independent clean-main failure is intentionally outside this PR and has been handed off for a separate bisect/fix.