### PR TITLE
Preserve overridable SBML parameter defaults

### DIFF
--- a/src/systems.jl
+++ b/src/systems.jl
@@ -217,11 +217,7 @@ function Catalyst.ReactionSystem(model::SBML.Model; kwargs...)  # Todo: requires
     return complete(rs)  # Todo: maybe add a `complete=True` kwarg
 end
 
-# Catalyst v16 replaced the single `defaults` kwarg of `ReactionSystem` with
-# separate `bindings` (parameter values) and `initial_conditions` (species/unknown
-# values). Older Catalyst (v14, v15) still uses `defaults`. This shim splits the
-# merged dictionary and dispatches on the installed Catalyst version so the same
-# SBMLToolkit code base supports both APIs.
+# Catalyst v16 distinguishes immutable symbolic bindings from overridable initial values.
 @static if pkgversion(Catalyst) >= v"16"
     function _build_reaction_system(eqs, iv, unknowns, ps, defs, cevs; kwargs...)
         unknown_set = Set(SymbolicUtils.unwrap(u) for u in unknowns)
@@ -231,12 +227,7 @@ end
         for (k, v) in defs
             if SymbolicUtils.unwrap(k) in unknown_set
                 initial_conditions[k] = v
-            elseif _references_non_parameter(v, param_set)
-                # SBML `initialAssignment`s on parameters may reference species
-                # (e.g. `parameter S3 := k1*S2`); those cannot live in `bindings`
-                # under Catalyst v16 (`check_bindings` rejects non-parameter symbols)
-                # but are accepted as `initial_conditions`, which is evaluated at
-                # t=0 with the same SBML semantics.
+            elseif _is_initial_condition(v, param_set)
                 initial_conditions[k] = v
             else
                 bindings[k] = v
@@ -250,14 +241,9 @@ end
         )
     end
 
-    function _references_non_parameter(v, param_set)
-        # Note: Symbolics.Num <: Real <: Number, so a `v isa Number` early-return
-        # would swallow symbolic values. Use `get_variables` directly — it returns
-        # an empty iterator for plain numerics.
-        for var in Symbolics.get_variables(v)
-            SymbolicUtils.unwrap(var) in param_set || return true
-        end
-        return false
+    function _is_initial_condition(v, param_set)
+        vars = Symbolics.get_variables(v)
+        return isempty(vars) || any(SymbolicUtils.unwrap(var) ∉ param_set for var in vars)
     end
 else
     function _build_reaction_system(eqs, iv, unknowns, ps, defs, cevs; kwargs...)

--- a/test/systems.jl
+++ b/test/systems.jl
@@ -137,11 +137,9 @@ if pkgversion(ModelingToolkit) >= v"11"
     bindings = ModelingToolkit.bindings(odesys)
     @test all(
         isequal(Symbolics.wrap(initial_conditions[Symbolics.unwrap(k)]), v)
-            for (k, v) in u0
+            for (k, v) in testdef
     )
-    @test all(
-        isequal(Symbolics.wrap(bindings[Symbolics.unwrap(k)]), v) for (k, v) in par
-    )
+    @test isempty(bindings)
 else
     @test issubset(testdef, ModelingToolkit.defaults(odesys))
 end
@@ -168,18 +166,19 @@ if pkgversion(ModelingToolkit) >= v"11"
     bindings = ModelingToolkit.bindings(odesys)
     @test all(
         isequal(Symbolics.wrap(initial_conditions[Symbolics.unwrap(k)]), v)
-            for (k, v) in u0
+            for (k, v) in testdef
     )
-    @test all(
-        isequal(Symbolics.wrap(bindings[Symbolics.unwrap(k)]), v) for (k, v) in par
-    )
+    @test isempty(bindings)
 else
     @test issubset(testdef, ModelingToolkit.defaults(odesys))
 end
 @named odesys = ODESystem(MODEL1)
 isequal(nameof(odesys), :odesys)
 
-@test ODEProblem(odesys, [], [0.0, 1.0], []) isa ODEProblem
+prob = ODEProblem(odesys, [], [0.0, 1.0])
+@test prob isa ODEProblem
+override_prob = ODEProblem(odesys, [k1 => 2.0], [0.0, 1.0])
+@test override_prob.ps[k1] == 2.0
 
 # # Test ODEProblem
 # oprob = ODEProblem(ODESystem(MODEL1), [], [0.0, 1.0], [])
@@ -218,6 +217,14 @@ parammap_true = [k1 => 1.0, SBMLToolkit.create_var("k2") => k1]
 initial_assignment_map_true = [SBMLToolkit.create_var("k2") => k1]
 @test isequal(parammap, parammap_true)
 @test isequal(initial_assignment_map, initial_assignment_map_true)
+if pkgversion(Catalyst) >= v"16"
+    rs = ReactionSystem(m)
+    initial_conditions = ModelingToolkit.initial_conditions(rs)
+    bindings = ModelingToolkit.bindings(rs)
+    k2 = first(parammap_true[2])
+    @test isequal(Symbolics.wrap(initial_conditions[Symbolics.unwrap(k1)]), 1.0)
+    @test isequal(Symbolics.wrap(bindings[Symbolics.unwrap(k2)]), k1)
+end
 
 m = SBML.Model(
     species = Dict("s2" => SPECIES2),


### PR DESCRIPTION
Ignore this PR until it has been reviewed by @ChrisRackauckas.

## What changed

Catalyst 16 distinguishes overridable initial/default values from immutable symbolic parameter bindings. SBMLToolkit's Catalyst 16 compatibility path classified every literal SBML parameter value as a binding, so standard SBML parameter defaults could not be overridden when constructing or remaking a problem.

This classifies values with no symbolic dependencies as `initial_conditions`, while retaining parameter-only symbolic expressions as `bindings`. Expressions that reference a state remain initial conditions, preserving the existing handling required by Catalyst's binding validation.

The regression begins at [`d2dcf2c405db1bfbccfa4f52ed44348dc2bd4205`](https://github.com/SciML/SBMLToolkit.jl/commit/d2dcf2c405db1bfbccfa4f52ed44348dc2bd4205), introduced in [PR 201](https://github.com/SciML/SBMLToolkit.jl/pull/201). Its parent works with the prior supported Catalyst 15 stack (`Catalyst=15.0.11 ModelingToolkit=9.84.0 retcode=Success`).

## Failing before

On clean `main` at `3222444`, the Carcione model reaches the following failure after switching its removed reaction-system conversion to the public `ODESystem(mdl)` constructor:

```text
┌ Warning: gamma is not a non-dependent parameter in the system.
ERROR: AssertionError: Expected an Initial parameter to exist for variable gamma. If it is a bound parameter, it cannot be given initial conditions.
```

Applying only the new initial-condition expectation to the unfixed source also fails in `test/systems.jl`:

```text
Error During Test at test/systems.jl:137
  Test threw exception
  Expression: all(isequal(Symbolics.wrap(initial_conditions[Symbolics.unwrap(k)]), v) for (k, v) in testdef)
  KeyError: key k1 not found
```

## Passing after

```text
$ GROUP=Core julia +1.11 --project=. --startup-file=no -e 'using Pkg; Pkg.test()'
Test Summary: | Pass  Total   Time
Core/systems.jl |   47     47  12.3s
Test Summary:   | Pass  Total     Time
Core/wuschel.jl |    2      2  2m15.0s
Testing SBMLToolkit tests passed

$ GROUP=QA julia +1.11 --project=. --startup-file=no -e 'using Pkg; Pkg.test()'
Test Summary: | Pass  Total     Time
QA/qa.jl      |   28     28  1m59.3s
Testing SBMLToolkit tests passed

$ julia +1.12 --project=@runic -e 'using Runic; exit(Runic.main(["--check", "src/systems.jl", "test/systems.jl"]))'
# exit 0

$ typos src/systems.jl test/systems.jl
# exit 0

$ git diff --check
# exit 0
```

The regression test additionally constructs an `ODEProblem` with `k1 => 2.0` and observes `override_prob.ps[k1] == 2.0`. It also verifies that the literal `k1 = 1.0` is an initial condition while the genuinely symbolic initial assignment `k2 = k1` remains a binding.

No dependencies or compatibility bounds change. SBMLToolkit and Catalyst are MIT-licensed.

🤖 Generated with Codex CLI 0.151.0 (model: gpt-5.6-sol; session: local session ID 01a0598f-11b9-72d1-91d9-b2fbb186557d)
