### PR TITLE
Let assignment rules determine their initial values

### DIFF
--- a/src/systems.jl
+++ b/src/systems.jl
@@ -175,7 +175,7 @@ function Catalyst.ReactionSystem(model::SBML.Model; kwargs...)  # Todo: requires
                 rhs = r.rhs
             end
         end
-        defs[o.lhs] = Symbolics.fixpoint_sub(rhs, defs)
+        delete!(defs, Num(o.lhs))
         #  ModelingToolkit._merge(defs,
         #                         Dict(Catalyst.DEFAULT_IV.val => 0)))
         push!(obsrules_rearranged, 0 ~ rhs - o.lhs)

--- a/test/systems.jl
+++ b/test/systems.jl
@@ -1,5 +1,6 @@
 using SBMLToolkit
 using Catalyst, ModelingToolkit, SBML
+using OrdinaryDiffEq
 import Symbolics
 using Test
 
@@ -260,3 +261,27 @@ ns = SBMLToolkit.netstoich("s1", r)
 @test readSBML(sbmlfile, DefaultImporter()) isa SBML.Model
 @test readSBML(sbmlfile, ReactionSystemImporter()) isa ReactionSystem
 @test readSBML(sbmlfile, ODESystemImporter()) isa ODESystem
+
+@testset "Assignment rule follows initial-value override" begin
+    model = SBML.Model(
+        compartments = Dict("c1" => SBML.Compartment(size = 1.0, constant = true)),
+        species = Dict("s1" => SPECIES1),
+        parameters = Dict("lambda" => SBML.Parameter(value = 999.0, constant = false)),
+        reactions = Dict(
+            "r1" => SBML.Reaction(
+                products = [SBML.SpeciesReference(species = "s1", stoichiometry = 1.0)],
+                kinetic_math = SBML.MathIdent("lambda"), reversible = false
+            )
+        ),
+        rules = SBML.Rule[
+            SBML.AssignmentRule(
+                "lambda", SBML.MathApply("*", SBML.Math[SBML.MathVal(2.0), SBML.MathIdent("s1")])
+            ),
+        ]
+    )
+    sys = structural_simplify(ODESystem(model))
+    prob = ODEProblem(sys, [sys.s1 => 3.0], (0.0, 1.0))
+    sol = solve(prob, Rodas5P())
+    @test successful_retcode(sol)
+    @test sol[sys.lambda][1] == 6.0
+end


### PR DESCRIPTION
## What changed

Do not impose an initial condition on an SBML assignment-rule target. The importer currently evaluates the rule using the original defaults and stores that result as a fixed initial condition. Changing an input's initial value then leaves a contradictory constraint and produces `InitialFailure`. Remove the target's default, including its original literal value, and let the assignment equation determine it.

This follows the SBML assignment-rule semantics: the rule applies at all times and overrides the target's defining value attribute. Reference: https://sbml.org/software/libsbml/5.18.0/docs/formatted/java-api/org/sbml/libsbml/AssignmentRule.html . No new public API or dependencies.

## Verification

Julia 1.11.9, ModelingToolkit 11.41.0, ModelingToolkitBase 1.68.2. The focused model has `lambda = 2*s1`, an original species initial value of 1, and a literal lambda value of 999 which the assignment rule overrides. Constructing the problem with `s1 => 3` must initialize lambda to 6 and solve successfully.

Identical standalone test before/after, using the same dependency environment and changing only SBMLToolkit source:

```sh
julia --project=SBML-assignment-main-env EMA-carcione-clean-env/sbml_assignment_reducer.jl
```

Before on clean main 3222444c7ca8c103d6d4319f4745933b2c499040:

```text
ASSIGNMENT_RETCODE=InitialFailure
successful_retcode(sol): false
sol[sys.lambda][1] == 6.0: 2.0 == 6.0
Assignment rule follows initial-value override | 2 fail
```

After:

```text
ASSIGNMENT_RETCODE=Success
Assignment rule follows initial-value override | 2 pass, 2 total
```

`GROUP=QA julia --project=SBML-assignment-main-env -e 'using Pkg; Pkg.test("SBMLToolkit")'` passed `QA/qa.jl | 28/28` (15m26.1s), exit 0.

Native Core commands:

```sh
GROUP=Core julia --project=SBMLToolkit-assignment-before -e 'using Pkg; Pkg.test()'
GROUP=Core julia --project=SBML-assignment-main-env -e 'using Pkg; Pkg.test("SBMLToolkit")'
```

The clean production checkout with the identical new official regression fails, exit 1:

```text
Core/systems.jl | 44 pass, 2 fail, 46 total
Assignment rule follows initial-value override | 2 fail
Expression: successful_retcode(sol)
Expression: (sol[sys.lambda])[1] == 6.0
Evaluated: 2.0 == 6.0
```

With the fix, the complete native Core group passes, exit 0:

```text
Core/events.jl | 4/4
Core/precompile_workload.jl | 1/1
Core/reactions.jl | 28/28
Core/rules.jl | 11/11
Core/simresults.jl | 9/9
Core/systems.jl | 46/46
Core/utils.jl | 11/11
Core/wuschel.jl | 2/2
Testing SBMLToolkit tests passed
```

An independent historical reproduction also fails both assertions on the clean pre-MTK11-migration importer (2f65b7a, Catalyst 15.0.11, ModelingToolkit 9.84.0). The failure therefore predates that migration. The exact runtime-introducing commit was not established; source history alone is not claimed as a bisect.

Runic, diff spelling, and `git diff --check` passed. No assertions were loosened and no tests or initialization checks were disabled.

## Not verified

Full downstream EasyModelAnalysis documentation and GPU paths were not verified. This source-only bug fix adds no docstrings or public API, so documentation was not built. Parameter overrides in models with constant SBML parameters require the separate fix at https://github.com/SciML/SBMLToolkit.jl/pull/239 ; this regression changes a species initial value and reproduces independently of that PR.

Please ignore this draft until reviewed by @ChrisRackauckas.

🤖 Generated with Codex CLI 0.153.4 (model: gpt-6-astra; session: local transcript `/home/crackauc/.codex/sessions/2026/09/05/rollout-2026-09-05T05-08-31-01a070d3-9e50-71c2-98f5-129385e50fb7.jsonl`).
