### PR TITLE
Release SBMLToolkit 0.1.42

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SBMLToolkit"
 uuid = "86080e66-c8ac-44c2-a1a0-9adaadfe4a4e"
 authors = ["paulflang", "anandijain"]
-version = "0.1.41"
+version = "0.1.42"
 
 [deps]
 Catalyst = "479239e8-5488-4da2-87a7-35f2df7eef83"


### PR DESCRIPTION
Bumps `SBMLToolkit` 0.1.41 -> 0.1.42 (patch).

Source files changed since 0.1.41:
- `src/systems.jl`

Commits:
- Preserve overridable SBML parameter defaults (#239)

Version bump only; no code changes in this PR.


🤖 Generated with [Claude Code](https://claude.com/claude-code) (model: claude-opus-5[1m])

https://claude.ai/code/session_014FEzNTLFutCmTEAZ3zBg5R
