### PR TITLE
Require Symbolics 7.39.2 (32-bit hasha_seed)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -26,7 +26,7 @@ SafeTestsets = "0.1"
 SciMLTesting = "2.4"
 Sundials = "6.2"
 SymbolicUtils = "4"
-Symbolics = "7"
+Symbolics = "7.39.2"
 Test = "1"
 julia = "1.10"
 


### PR DESCRIPTION
## Summary
Force Symbolics ≥7.39.2 for i686 SymbolicUtils hasha_seed fix.

## Test plan
- [ ] x86 Core green

Made with [Cursor](https://cursor.com)