### PR TITLE
Add AirspeedVelocity benchmarking CI

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,0 +1,29 @@
+name: Benchmark this PR
+
+on:
+  pull_request:
+    branches: [main]
+    paths-ignore: ['docs/**']
+
+permissions:
+  pull-requests: write
+  contents: read
+
+jobs:
+  benchmark:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        version: ["1", "lts"]
+    env:
+      # Force consistent Julia depot path for self-hosted runners
+      JULIA_DEPOT_PATH: ~/.julia
+    steps:
+      - uses: MilesCranmer/AirspeedVelocity.jl@action-v1
+        with:
+          julia-version: ${{ matrix.version }}
+          script: "benchmark/benchmarks.jl"
+          extra-pkgs: ""
+          job-summary: true

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -1,0 +1,24 @@
+using SBMLToolkit, BenchmarkTools
+
+const SUITE = BenchmarkGroup()
+
+data_dir = joinpath(@__DIR__, "..", "test", "data")
+
+# =============================================================================
+# SBML reading → ReactionSystem/ODESystem
+# =============================================================================
+
+SUITE["read"] = BenchmarkGroup()
+
+SUITE["read"]["model_26"] = @benchmarkable readSBML(
+    joinpath($data_dir, "00026-sbml-l3v2.xml")
+)
+SUITE["read"]["model_31"] = @benchmarkable readSBML(
+    joinpath($data_dir, "00031-sbml-l3v2.xml")
+)
+SUITE["read"]["model_31_odesys"] = @benchmarkable readSBML(
+    joinpath($data_dir, "00031-sbml-l3v2.xml"), ODESystemImporter()
+)
+SUITE["read"]["model_31_rssys"] = @benchmarkable readSBML(
+    joinpath($data_dir, "00031-sbml-l3v2.xml"), ReactionSystemImporter()
+)


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/benchmark.yml` running AirspeedVelocity on pull requests (Julia `1` and `lts`, 30 min timeout), following the OrdinaryDiffEq.jl setup.
- Adds `benchmark/benchmarks.jl` with a small `SUITE` covering representative workloads for this package.

The suite was verified locally in a fresh environment: it loads and all benchmarks run in ~63s.

#### Test plan

- [x] `run(SUITE)` locally: all benchmarks pass (~63s)
- [x] Runic formatting clean on `benchmark/benchmarks.jl`
- [ ] \"Benchmark this PR\" workflow triggers and completes on this PR

🤖 Generated with [Devin](https://devin.ai) (harness: devin 3000.10.21, model: SWE-2 Max)
Session: local transcript /home/crackauc/.local/share/devin/cli/summaries/history_ccb52064e6514b21.md